### PR TITLE
Suggest python=3.10 in conda create.

### DIFF
--- a/instructions/INSTALLATION.md
+++ b/instructions/INSTALLATION.md
@@ -13,7 +13,7 @@ This repository is validated on Python 3.10, [requirements.txt](/requirements.tx
 ```bash
 # create a new anaconda environment
 conda config --add channels https://conda.anaconda.org/gurobi
-conda create --name facet --file requirements.txt
+conda create --name facet --file requirements.txt python=3.10
 conda activate facet
 # if running SOTA comparison method MACE, install required solver
 pysmt-install --z3 --confirm-agreement


### PR DESCRIPTION
Feel free to not take this PR - I haven't used conda in years and I might be using it incorrectly.

With these changes, `conda create` solves the environment much faster (instant vs at least a few minutes).
My understanding is that if you don't specify the Python version, it searches packages across all Python versions.